### PR TITLE
bump paramiko requirement to 1.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ function(find_python_module module minver)
         find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
 endfunction(find_python_module)
 
-find_python_module(paramiko 1.15.1 QUIET)
+find_python_module(paramiko 1.16.0 QUIET)
 if(NOT PY_PARAMIKO)
   message(WARNING "Paramiko wasn't found, you can still build Workbench, but may not work properly.")
 endif()

--- a/README
+++ b/README
@@ -38,7 +38,7 @@ components at the following locations:
 
 glib-2.23.5     - http://downloads.mysql.com/source/lgpl/glib-2.23.5.tar.gz
 libzip-0.9.3    - http://downloads.mysql.com/source/lgpl/libzip-0.9.3.tar.gz
-paramiko-1.7.6  - http://downloads.mysql.com/source/lgpl/paramiko-1.7.6.tar.gz
+paramiko-1.16.0 - http://downloads.mysql.com/source/lgpl/paramiko-1.16.0.tar.gz
 libiconv-1.13.1 - http://downloads.mysql.com/source/lgpl/libiconv-1.13.1.tar.gz
 
 Note: These source code downloads are provided for LGPL compliance. 

--- a/build/debian.in/control
+++ b/build/debian.in/control
@@ -15,7 +15,7 @@ Replaces: mysql-workbench-com-se, mysql-workbench, mysql-workbench-community, my
 @ifdef paramiko
 Depends: ${shlibs:Depends}, libglib2.0-0 (>= 2.28)
 @else
-Depends: ${shlibs:Depends}, python-paramiko (>= 1.15.1), libglib2.0-0 (>= 2.28)
+Depends: ${shlibs:Depends}, python-paramiko (>= 1.16.0), libglib2.0-0 (>= 2.28)
 @endif
 Architecture: i386 amd64
 Suggests: gnome-keyring

--- a/build/debian.in/control.commercial
+++ b/build/debian.in/control.commercial
@@ -12,7 +12,7 @@ Replaces: mysql-workbench-com-se
 @ifdef paramiko
 Depends: ${shlibs:Depends}, python-pysqlite2, mysql-client|virtual-mysql-client, libglib2.0-0 (>= 2.28)
 @else
-Depends: ${shlibs:Depends}, python-paramiko (>= 1.15.1), python-pysqlite2, mysql-client|virtual-mysql-client, libglib2.0-0 (>= 2.28)
+Depends: ${shlibs:Depends}, python-paramiko (>= 1.16.0), python-pysqlite2, mysql-client|virtual-mysql-client, libglib2.0-0 (>= 2.28)
 @endif
 
 Suggests: gnome-keyring

--- a/build/mysql-workbench.spec.in
+++ b/build/mysql-workbench.spec.in
@@ -106,7 +106,7 @@ Provides: mysql-workbench%{?_isa} = %{version}-%{release}
 Requires: tinyxml
 Requires: libzip
 %if %{without paramiko}
-Requires: python-paramiko >= 1.15.1
+Requires: python-paramiko >= 1.16.0
 %endif
 Requires: gnome-keyring
 Requires: proj


### PR DESCRIPTION
[Paramiko 1.16.0](http://www.paramiko.org/changelog.html) adds support for the SHA2 family of hash functions (both for the MAC and for the key exchange). This is great, because OpenSSH added support for them in [OpenSSH 5.9](http://www.openssh.com/txt/release-5.9) (September 2011) and removed the older SHA1 and MD5 functions from the default allowed MAC list in [OpenSSH 7.0](http://www.openssh.com/txt/release-7.0) (August 2015). Given the current buzz about "[SLOTH](http://www.mitls.org/pages/attacks/SLOTH)", there will be probably be a lot more people removing MD5 and SHA1 from their sshd configurations soon.

I hope that this change will be sufficient; unfortunately, I could not actually get mysqlworkbench to build on my OS X box, so there may be other changes required. It did verify that mysqlworkbench works and can connect to an OpenSSH 7.1 server if I take the existing upstream .app bundle and manually replace the `Contents/Resources/libraries/paramiko` directory with the latest paramiko package from pypi (and then ignore a large number of warnings from OS X that the bundle signature is invalid, but whatever).