### PR TITLE
Data Migration: Changed sybase `getTriggerNames` to singlequoted search on 'TR'

### DIFF
--- a/modules/db.sybase/db_sybase_re_grt.py
+++ b/modules/db.sybase/db_sybase_re_grt.py
@@ -291,7 +291,7 @@ def getTriggerNames(connection, catalog_name, schema_name):
     execute_query(connection, 'USE %s' % quoteIdentifier(catalog_name))
     query = """SELECT name
 FROM sysobjects
-WHERE type="TR" AND uid = user_id(?)"""
+WHERE type='TR' AND uid = user_id(?)"""
     return [ row[0] for row in execute_query(connection, query, schema_name) ]
 
 


### PR DESCRIPTION
When The ODBC `DelimitIdentifier=Yes`, Sybase gives an error during the data migration:

```
Traceback (most recent call last):
  File "MySQL Workbench 6.3.6 CE (win32)\modules\db_sybase_re_grt.py", line 358, in reverseEngineer
    trigger_count_per_schema[schema_name] = len(getTriggerNames(connection, catalog_name, schema_name)) if get_triggers else 0
  File "MySQL Workbench 6.3.6 CE (win32)\modules\db_sybase_re_grt.py", line 295, in getTriggerNames
    return [ row[0] for row in execute_query(connection, query, schema_name) ]
  File "MySQL Workbench 6.3.6 CE (win32)\modules\db_sybase_re_grt.py", line 65, in execute_query
    return get_connection(connection_object).cursor().execute(query, *args, **kwargs)
pyodbc.Error: ('ZZZZZ', "[ZZZZZ] [Sybase][ODBC Driver][Adaptive Server Enterprise]Invalid column name 'TR'.\n (207) (SQLExecDirectW)")
 
Traceback (most recent call last):
  File "MySQL Workbench 6.3.6 CE (win32)\workbench\wizard_progress_page_widget.py", line 192, in thread_work
    self.func()
  File "MySQL Workbench 6.3.6 CE (win32)\modules\migration_schema_selection.py", line 175, in task_reveng
    self.main.plan.migrationSource.reverseEngineer()
  File "MySQL Workbench 6.3.6 CE (win32)\modules\migration.py", line 369, in reverseEngineer
    self.state.sourceCatalog = self._rev_eng_module.reverseEngineer(self.connection, self.selectedCatalogName, self.selectedSchemataNames, self.state.applicationData)
SystemError: Error("('ZZZZZ', "[ZZZZZ] [Sybase][ODBC Driver][Adaptive Server Enterprise]Invalid column name 'TR'.\n (207) (SQLExecDirectW)")"): error calling Python module function DbSybaseRE.reverseEngineer
ERROR: Reverse engineer selected schemas: Error("('ZZZZZ', "[ZZZZZ] [Sybase][ODBC Driver][Adaptive Server Enterprise]Invalid column name 'TR'.\n (207) (SQLExecDirectW)")"): error calling Python module function DbSybaseRE.reverseEngineer
Failed
```
