### PR TITLE
Change generated column flag's tool tip message in table editor

### DIFF
--- a/plugins/db.mysql.editors/macosx/MySQLTableEditor.xib
+++ b/plugins/db.mysql.editors/macosx/MySQLTableEditor.xib
@@ -425,7 +425,7 @@
                                                     <font key="font" metaFont="smallSystem"/>
                                                 </buttonCell>
                                             </tableColumn>
-                                            <tableColumn identifier="generated" width="25" minWidth="10" maxWidth="3.4028229999999999e+38" headerToolTip="Mark column as AUTO_INCREMENT" id="Pii-GS-Al3" userLabel="G">
+                                            <tableColumn identifier="generated" width="25" minWidth="10" maxWidth="3.4028229999999999e+38" headerToolTip="Mark column as Generated Column" id="Pii-GS-Al3" userLabel="G">
                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="G">
                                                     <font key="font" metaFont="smallSystem"/>
                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
I found tiny bug in table editor.
when mouse cursor on 'G' flag, 'Mark column as AUTO_INCREMENT' tooltip message is shown.
then, i fix that tooltip message to 'Mark column as Generated Column'