### PR TITLE
fix compilation with gcc 6.2.1

### DIFF
--- a/library/forms/gtk/src/lf_popover.cpp
+++ b/library/forms/gtk/src/lf_popover.cpp
@@ -380,7 +380,7 @@ void PopoverWidget::show_popover(const int rx, const int ry, const mforms::Start
   if (_style == mforms::PopoverStyleTooltip)
   {
     Glib::RefPtr<Gdk::Window> wnd = this->get_window();
-    if (wnd != 0)
+    if (wnd)
     {
       int xx;
       int yy;
@@ -396,7 +396,7 @@ void PopoverWidget::show_popover(const int rx, const int ry, const mforms::Start
   {
     Gdk::ModifierType mask;
     Glib::RefPtr<Gdk::Display> dsp = Gdk::Display::get_default();
-    if (dsp != 0)
+    if (dsp)
       dsp->get_pointer(x, y, mask);
   }
 

--- a/library/forms/gtk/src/lf_popup.cpp
+++ b/library/forms/gtk/src/lf_popup.cpp
@@ -81,7 +81,8 @@ void PopupImpl::on_screen_changed(const Glib::RefPtr<Gdk::Screen>& screen)
 {
   d("\n");
   Glib::RefPtr<Gdk::Colormap> colormap = screen->get_rgba_colormap();
-  _have_rgba = colormap;
+  if (colormap)
+    _have_rgba = true;
 
   if (!_have_rgba)
     colormap = screen->get_rgb_colormap();


### PR DESCRIPTION
Compilation fails with recent versions of gcc with:

error: cannot convert 'Glib::RefPtr<Gdk::Colormap>' to 'bool' in
assignment

and

error: no match for 'operator!=' (operand types are
'Glib::RefPtr<Gdk::Window>' and 'int')

This fixes compilation with gcc 6.2.1.