### PR TITLE
TUNNEL_TIMEOUT causing ssh tunnel connection failures - Update sshtunnel.py

### DIFF
--- a/library/sshtunnel/sshtunnel.py
+++ b/library/sshtunnel/sshtunnel.py
@@ -39,7 +39,7 @@ SSH_PORT = 22
 REMOTE_PORT = 3306
 
 # timeout for closing an unused tunnel
-TUNNEL_TIMEOUT = 3
+TUNNEL_TIMEOUT = 60
 
 # paramiko 1.6 didn't have this class
 if hasattr(paramiko, "WarningPolicy"):


### PR DESCRIPTION
MySQL Workbench 3.6.3 connecting to a server over SSH with no SSL works fine.
MySQL Workbench 3.6.7 and 3.6.8 (other versions untested) connecting to server over SSH with no SSL does not work.

After running version 3.6.3 and 3.6.8 in debug mode logging to console the following was found:
V3.6.3 DEBUG OUTPUT-
21:51:50 [ERR][  GRTDispatcher]: exception in grt execute_task, continuing: Exception: Access denied for user 'root'@'127.0.0.1' (using password: NO)
21:51:50 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO Client for 42829 disconnected
21:51:50 [ERR][  GRTDispatcher]: worker: task 'execute sql queries' has failed with error:.Access denied for user 'root'@'127.0.0.1' (using password: NO)
21:51:50 [DB1][ mforms backend]: Looking up password for 'root'@'Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX' has failed
21:51:50 [DB1][ mforms backend]: Forgetting password for 'root'@'Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX'
21:51:50 [DB1][ mforms backend]: Creating and showing password dialog
21:51:58 [DB3][  GRTDispatcher]: GRT dispatcher, running task execute sql queriestunnel_42829: INFO New client connection
21:51:58 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO Client connection established
21:51:58 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO Tunnel now open ('127.0.0.1', 55839) -> ('XXX.XXX.XXX.XXX', 22) -> ('127.0.0.1', 3306)
21:51:59 [DB1][      SqlEditor]: Notifying server state change of Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX to running
21:51:59 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO New client connection
21:51:59 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO Client connection established
21:51:59 [DB2][sshtunnel.py:notify:228]: tunnel_42829: INFO Tunnel now open ('127.0.0.1', 55840) -> ('XXX.XXX.XXX.XXX', 22) -> ('127.0.0.1', 3306)

V3.6.8 DEBUG OUTPUT-
21:49:08 [ERR][  GRTDispatcher]: exception in grt execute_task, continuing: Exception: Access denied for user 'root'@'127.0.0.1' (using password: NO)
21:49:08 [ERR][  GRTDispatcher]: worker: task 'execute sql queries' has failed with error:.Access denied for user 'root'@'127.0.0.1' (using password: NO)
21:49:08 [DB1][ mforms backend]: Looking up password for 'root'@'Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX' has failed
21:49:08 [DB2][ mforms backend]: Forgetting cached password for 'root'@'Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX'
21:49:08 [DB1][ mforms backend]: Forgetting password for 'root'@'Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX'
21:49:08 [DB1][ mforms backend]: Creating and showing password dialog
21:49:11 [DB2][sshtunnel.py:notify:229]: tunnel_60687: INFO Closing tunnel to XXX.XXX.XXX.XXX:22 for inactivity...
21:49:11 [DB1][sshtunnel.py:do_run:226]: Leaving tunnel thread 60687
21:49:57 [DB3][  GRTDispatcher]: GRT dispatcher, running task execute sql queriesNotifying server state change of Mysql@127.0.0.1:3306@XXX.XXX.XXX.XXX to not running
21:49:57 [ERR][      SqlEditor]: SqlEditorForm: exception in do_connect method: Exception: Can't connect to MySQL server on '127.0.0.1' (61)
21:49:57 [ERR][      SqlEditor]: Connection failed but remote admin does not seem to be available, rethrowing exception...

Manually changed sshtunnel.py TUNNEL_TIMEOUT = 60 and 3.6.8 SUCCESSFULLY connected to server. Tested manual change in 3.6.7 and also fixed the connection issue. I did not debug with 3.6.7

Possibly related to Bug #74896 (this solution solved that problem. I'm not qualified to diagnose relationship between the two).
