### PR TITLE
Fix for Bug #80560 - Sorting Client Connections does not update row r…

### DIFF
--- a/library/forms/gtk/src/lf_treenodeview.cpp
+++ b/library/forms/gtk/src/lf_treenodeview.cpp
@@ -1935,7 +1935,7 @@ std::list<TreeNodeRef> TreeNodeViewImpl::get_selection(TreeNodeView *self)
     if (size > 0)
     {
       for(size_t index = 0; index < size; index++)
-        selection.push_back(TreeNodeRef(new TreeNodeImpl(tree, tree->_tree_store, path_selection[index])));
+        selection.push_back(TreeNodeRef(new TreeNodeImpl(tree, tree->_tree_store, tree->_sort_model->convert_path_to_child_path(path_selection[index]))));
     }
   }
   else


### PR DESCRIPTION
…eference

I've fixed Bug #80560. The problem was that the get_selection function did not consider the current sorting. Conveniently, TreeSortModel has a function that translates a TreePath in the Sorted Model back to the original stored model.

I've sent the OCA.

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.