### PR TITLE
gdal: use CPLFree()

### DIFF
--- a/backend/wbpublic/grt/spatial_handler.cpp
+++ b/backend/wbpublic/grt/spatial_handler.cpp
@@ -443,7 +443,7 @@ spatial::Importer::Importer() : _geometry(NULL), _interrupt(false), _srid(0) {
 
 spatial::Importer::~Importer() {
   if (_geometry != NULL)
-    OGRFree(_geometry);
+    CPLFree(_geometry);
 }
 
 OGRGeometry *spatial::Importer::steal_data() {
@@ -495,7 +495,7 @@ std::string spatial::Importer::as_wkt() {
       logError("Error exporting data to WKT (%i)\n", err);
     } else {
       std::string tmp(data);
-      OGRFree(data);
+      CPLFree(data);
       return tmp;
     }
   }

--- a/backend/wbpublic/objimpl/db.query/db_query_Resultset.cpp
+++ b/backend/wbpublic/objimpl/db.query/db_query_Resultset.cpp
@@ -47,7 +47,7 @@ static grt::StringRef getGeoRepresentation(grt::StringRef data, bool outputAsJso
     OGRGeometryFactory::createFromWkb((unsigned char *)const_cast<char *>(&(*((*data).begin() + 4))), NULL, &geometry);
   if (ret_val != OGRERR_NONE) {
     if (geometry)
-      OGRFree(geometry);
+      CPLFree(geometry);
     throw std::exception();
   }
 
@@ -61,8 +61,8 @@ static grt::StringRef getGeoRepresentation(grt::StringRef data, bool outputAsJso
 
     if (err == OGRERR_NONE && data != NULL) {
       grt::StringRef tmp(data);
-      OGRFree(data);
-      OGRFree(geometry);
+      CPLFree(data);
+      CPLFree(geometry);
       return tmp;
     } else
       throw std::runtime_error("Conversion of OGR geometry data failed");


### PR DESCRIPTION
OGRFree() is deprecated as of gdal 2.2.0, so use CPLFree() instead.