### PR TITLE
Add ubuntu 19.04 as supported to the build

### DIFF
--- a/build/gen_deb_sources.py
+++ b/build/gen_deb_sources.py
@@ -5,6 +5,7 @@
 
 
 output_distros = [
+    ("disco", "ubuntu19.04", "1904", ""),
     ("cosmic", "ubuntu18.10", "1810", ""),
     ("bionic", "ubuntu18.04", "1804", ""),
     ("artful", "ubuntu17.10", "1710", ""),


### PR DESCRIPTION
18.10 (`libzip4`) -> 19.04 (`libzip5`)

```
# lsb_release -rdc
Description:	Ubuntu Disco Dingo (development branch)
Release:	19.04
Codename:	disco
```

