### PR TITLE
Since this repo doesn't have "issues". I'll do it here: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ MySQL Workbench functionality covers five main topics:
 ![Performance dashboard](https://dev.mysql.com/doc/workbench/en/images/wb-performance-dashboard.png)
 
 The [code repository on Github](https://github.com/mysql/mysql-workbench) is where we publish a snapshot of our internal repository everytime a new release of the product is published. Use the [MySQL bug system](http://bugs.mysql.com/) to report any issue you have. You can use Github or the MySQL bug system to contribute to the development. File a pull request on Github or a new issue on the MySQL Bug system with your patch and we will take care of it.
+


### PR DESCRIPTION
YOU CANT REPORT BUGS A SIMPLE WAY QUICKLY

When you get an error in your MySQL Workbench, it asks you to report or not a bug. So here we go.

![image](https://user-images.githubusercontent.com/11032344/110121053-a3b74800-7d9c-11eb-9246-8ca9135a5e55.png)


Oracle just asks a FUCKING WHOLE PAGE FULL OF BUROCRACY TO FILL just to report a FUCKING BUG

You guys just can't do a simple way to report bugs here? WITHOUT ORACLE WONDERING TO KNOW WHERE I LIVE (WTFFFFFF) 

![oracle burocracy](https://user-images.githubusercontent.com/11032344/110120387-bda45b00-7d9b-11eb-823c-466750007978.PNG)


This is why the repo doesn't receive 10 per cent of the problems it should have to being reported! No one will give the boring time to fill a bunch of fields "where the fuck I live" , "create an oracle account" just to report a disgrace of a bug!

You guys put in your mysql bug page:
- huh how to ask questions the right way by eric raymond
- durr how to have a good customer support 
- "How to Report Bugs Effectively" (YOU GOTTA BE KIDDING)

BLA BLA BLA

And just don't know hot to make a simple bug report system????? 

This is THE FIRST THING you guys should FIX ONCE FOR ALL

A bug appeared just letting the workbench opened the whole night, doing just NOTHING and appeared "a bug".

I AM JUST TIRED OF THIS SHIT WAY - MAKE THINGS SIMPLE!!!