### PR TITLE
fix https://bugs.mysql.com/bug.php?id=103207

### DIFF
--- a/library/python/workbench/os_utils.py
+++ b/library/python/workbench/os_utils.py
@@ -353,7 +353,7 @@ class OSUtils(object):
             # Note that self._command contains the internal command so EXEC
             # and self._args is the real OS command to be executed
             # Executes the command, reading the output from the PIPE
-            process = subprocess.Popen(command, stdin = subprocess.PIPE, encoding="utf-8", stdout = subprocess.PIPE, stderr = subprocess.STDOUT, shell=True)
+            process = subprocess.Popen(command, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.STDOUT, text=True, shell=True)
 
             # Sends all the command output to the listener
             if output_handler:


### PR DESCRIPTION
The default code page on Windows is not UTF-8. English users cannot repeat this issue because UTF-8 is backward compatible with ASCII.
Use `text=True` to let Python detect the encoding automatically.