### PR TITLE
Fix a bug: antlr4 grammar parse error

### DIFF
--- a/library/parsers/mysql/MySQLRecognizerCommon.h
+++ b/library/parsers/mysql/MySQLRecognizerCommon.h
@@ -1,12 +1,4 @@
 /*
- * @Descripttion: YD Security 
- * @version: 1.0
- * @Author: frank
- * @Date: 2021-11-18 09:34:16
- * @LastEditors: frank
- * @LastEditTime: 2021-11-18 09:37:47
- */
-/*
  * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify

--- a/library/parsers/mysql/MySQLRecognizerCommon.h
+++ b/library/parsers/mysql/MySQLRecognizerCommon.h
@@ -1,4 +1,12 @@
 /*
+ * @Descripttion: YD Security 
+ * @version: 1.0
+ * @Author: frank
+ * @Date: 2021-11-18 09:34:16
+ * @LastEditors: frank
+ * @LastEditTime: 2021-11-18 09:37:47
+ */
+/*
  * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -59,7 +67,7 @@ namespace parsers {
 
     // For parameterizing the parsing process.
     long serverVersion;
-    SqlMode sqlMode; // A collection of flags indicating which of relevant SQL modes are active.
+    SqlMode sqlMode = NoMode; // A collection of flags indicating which of relevant SQL modes are active.
 
     // Returns true if the given mode (one of the enums above) is set.
     bool isSqlModeActive(size_t mode);


### PR DESCRIPTION
when i use this grammar , i met a bug  as follows:

MySQLRecognizerCommon never initialize the field "sqlMode", so the subclass of MySQLRecognizerCommon perhaps uses the field uninitialized.

Always the field could be zero，because some memory mechanism it is zero, but C++ never gurantee this. I found when the program is big (has manay .cpp files)，the field initial value is not zero（maybe change some memory layout）， therefore cause a sql parse error.
   