### PR TITLE
:bug: Fix admin client connections

### DIFF
--- a/plugins/wb.admin/frontend/wb_admin_connections.py
+++ b/plugins/wb.admin/frontend/wb_admin_connections.py
@@ -343,7 +343,7 @@ class WbAdminConnections(WbAdminTabBase):
             self.columns = [("Id", mforms.LongIntegerColumnType, "Id", 50),
                             ("User", mforms.StringColumnType, "User", 80),
                             ("Host", mforms.StringColumnType, "Host", 120),
-                            ("DB", mforms.StringColumnType, "DB", 100),
+                            ("db", mforms.StringColumnType, "DB", 100),
                             ("Command", mforms.StringColumnType, "Command", 80),
                             ("Time", mforms.LongIntegerColumnType, "Time", 60),
                             ("State", mforms.StringColumnType, "State", 80),


### PR DESCRIPTION
On ubuntu 22.04 the client connections on the admin section do not load

The error is the following:
```
SystemError: DbMySQLQuery.resultFieldStringValueByName(): MySQL_ResultSet::isNull: invalid value of 'columnLabel'
```

This change fixes the issue

Found the fix here:
[https://velog.io/@neilkwon/MySQL-Workbench-8.x-Administration-Client-Connection-Exception](https://velog.io/@neilkwon/MySQL-Workbench-8.x-Administration-Client-Connection-Exception)