### PR TITLE
Fix checking for a new version

### DIFF
--- a/modules/wb.utils/wb_utils_grt.py
+++ b/modules/wb.utils/wb_utils_grt.py
@@ -589,7 +589,6 @@ class CheckForUpdateThread(threading.Thread):
         self.is_running = True
         try:
             import urllib.request, urllib.error, urllib.parse
-            import ssl
             import json
             import base64
 

--- a/modules/wb.utils/wb_utils_grt.py
+++ b/modules/wb.utils/wb_utils_grt.py
@@ -589,6 +589,7 @@ class CheckForUpdateThread(threading.Thread):
         self.is_running = True
         try:
             import urllib.request, urllib.error, urllib.parse
+            import ssl
             import json
             import base64
 
@@ -722,7 +723,7 @@ class CheckForUpdateThread(threading.Thread):
             self.error = "%s\n\nPlease verify that your internet connection is available." % str(error)        
     
     def checkForUpdatesCallback(self):
-        if self.isAlive():
+        if self.is_alive():
             return True  # Don't do anything until the dom is built
         
         if not self.json:


### PR DESCRIPTION
- Replace a dead method

Also, it looks like on Windows the packaged Python is missed (correct) SSL libraries. A quick workaround for the installed Workbench is to copy a few files from the standalone Python current version 3.11.4 into Python directories within Workbench hierarchy:

`_ssl.pyd, libcrypto-1_1.dll, libssl-1_1.dll from \Path\to\<Python>\DLLs into \Path\to\<Workbench>\python\DLLs` 
