### PR TITLE
erase empty string `defaultAuth` from `properties`

### DIFF
--- a/library/cdbc/src/driver_manager.cpp
+++ b/library/cdbc/src/driver_manager.cpp
@@ -493,6 +493,7 @@ namespace sql {
       std::list<std::string> prop_names;
       prop_names.push_back("socket");
       prop_names.push_back("schema");
+      prop_names.push_back("defaultAuth");
       for (const std::string &prop_name : prop_names) {
         ConnectOptionsMap::iterator prop_iter = properties.find(prop_name);
         if (properties.end() != prop_iter) {


### PR DESCRIPTION
This PR removes empty string `defaultAuth` from `properties`, since it confuses the connector for some MySQL servers.

Resolves https://bugs.mysql.com/bug.php?id=112931.