### PR TITLE
Fix support for libxml2-2.12 with its api and header changes

### DIFF
--- a/library/grt/src/grt.h
+++ b/library/grt/src/grt.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <stdexcept>
 #include <boost/function.hpp>
+#include <libxml/tree.h>
 #include <libxml/xmlmemory.h>
 #include "base/threading.h"
 #include <string>

--- a/library/grt/src/unserializer.cpp
+++ b/library/grt/src/unserializer.cpp
@@ -401,7 +401,11 @@ ValueRef internal::Unserializer::unserialize_xmldata(const char *data, size_t si
   xmlDocPtr doc = xmlReadMemory(data, (int)size, NULL, NULL, XML_PARSE_NOENT);
 
   if (!doc) {
+#if LIBXML_VERSION >= 21200
+    const xmlError* error = xmlGetLastError();
+#else
     xmlErrorPtr error = xmlGetLastError();
+#endif
 
     if (error)
       throw std::runtime_error(base::strfmt("Could not parse XML data. Line %d, %s", error->line, error->message));


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7

```
In file included from /var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/tools/genobj/genobj.cpp:32:
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2115:59: error: ‘xmlNodePtr’ has not been declared
 2115 |     static MetaClass *from_xml(const std::string &source, xmlNodePtr node);
      |                                                           ^~~~~~~~~~
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2153:19: error: ‘xmlNodePtr’ has not been declared
 2153 |     void load_xml(xmlNodePtr node);
      |                   ^~~~~~~~~~
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2154:30: error: ‘xmlNodePtr’ has not been declared
 2154 |     void load_attribute_list(xmlNodePtr node, const std::string &member = "");
      |                              ^~~~~~~~~~
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2534:5: error: ‘xmlDocPtr’ does not name a type
 2534 |     xmlDocPtr load_xml(const std::string &path);
      |     ^~~~~~~~~
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2535:27: error: ‘xmlDocPtr’ has not been declared
 2535 |     void get_xml_metainfo(xmlDocPtr doc, std::string &doctype_ret, std::string &version_ret);
      |                           ^~~~~~~~~
/var/tmp/portage/dev-db/mysql-workbench-8.0.36/work/mysql-workbench-community-8.0.36-src/library/grt/src/grt.h:2536:30: error: ‘xmlDocPtr’ has not been declared
 2536 |     ValueRef unserialize_xml(xmlDocPtr doc, const std::string &source_path);
 ```