### PR TITLE
Fix version check for 8.1+

### DIFF
--- a/library/python/workbench/utils.py
+++ b/library/python/workbench/utils.py
@@ -213,7 +213,7 @@ class Version:
         return self.compare(other) <= 0
 
     def is_supported_mysql_version(self):
-        if (self.majorNumber == 5 and self.minorNumber in (1, 5, 6, 7)) or (self.majorNumber == 8 and self.minorNumber == 0):
+        if (self.majorNumber == 5 and self.minorNumber in (1, 5, 6, 7)) or (self.majorNumber == 8):
             return True
         return False
 
@@ -228,7 +228,7 @@ class Version:
         # if the version required is older (<) than 5.6, then any server that matches is fine
         # if the version required is newer (>=) than 5.6, then we can only guarantee that known servers versions have some specific feature
         
-        if (major == 5 and minor >= 6) or (major == 8 and minor == 0):
+        if (major == 5 and minor >= 6) or (major == 8):
             return self.is_supported_mysql_version() and self >= Version(major, minor, release)
         else:
             return self > Version(major, minor, release)


### PR DESCRIPTION
The version check was hard coded to only support 8.0 exactly, which needlessly broke some Workbench features when using server versions 8.1-8.4.