### PR TITLE
Fix: startODBCAdmin() not working as expected in 64-bit Windows

### DIFF
--- a/modules/wb.utils/wb_utils_grt.py
+++ b/modules/wb.utils/wb_utils_grt.py
@@ -498,10 +498,10 @@ def startODBCAdmin():
         # so if we're a 64bit WB, then we run the 64bit odbc tool (since we can't use 32bit drivers anyway)
 
         if sys.maxsize > 2**31:
-            subprocess.Popen(r"%SYSTEMROOT%\SysWOW64\odbcad32.exe", shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP, close_fds=True)
-        else:
             subprocess.Popen(r"%SYSTEMROOT%\System32\odbcad32.exe", shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP, close_fds=True)
-            return 1
+        else:
+            subprocess.Popen(r"%SYSTEMROOT%\SysWOW64\odbcad32.exe", shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP, close_fds=True)
+        return 1
 
 
 def process_not_found_utils():


### PR DESCRIPTION
Fixes the following:
1. The function does not return a value on 64-bit WB
2. The function wrongly opens a 32-bit odbcad32.exe on 64-bit WB

Related issue: https://forums.mysql.com/read.php?152,707572,707572