### PR TITLE
fix building against swig 4.3.0

### DIFF
--- a/library/forms/swig/cairo.i
+++ b/library/forms/swig/cairo.i
@@ -125,7 +125,7 @@
 
 %typemap(argout) cairo_text_extents_t *extents {
       PyObject *o= SWIG_NewPointerObj(new cairo_text_extents_t(*$1), SWIGTYPE_p_cairo_text_extents_t, 0 |  0 );
-      $result= SWIG_Python_AppendOutput($result, o);
+      $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in) const char* (std::string s) {

--- a/library/forms/swig/mforms.i
+++ b/library/forms/swig/mforms.i
@@ -722,7 +722,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) std::string &ret_password {
     PyObject *o= PyUnicode_DecodeUTF8(($1)->data(), ($1)->size(), NULL);
-    $result= SWIG_Python_AppendOutput($result, o);
+    $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in,numinputs=0) std::string &ret_password(std::string temp) {
@@ -731,7 +731,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) std::string &ret_value {
     PyObject *o= PyUnicode_DecodeUTF8(($1)->data(), ($1)->size(), NULL);
-    $result= SWIG_Python_AppendOutput($result, o);
+    $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in,numinputs=0) std::string &ret_value(std::string temp) {
@@ -741,7 +741,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) bool &ret_store {
     if (*$1) Py_INCREF(Py_True); else Py_INCREF(Py_False);
-    $result= SWIG_Python_AppendOutput($result, *$1 ? Py_True : Py_False);
+    $result= SWIG_AppendOutput($result, *$1 ? Py_True : Py_False);
 }
 
 %typemap(in,numinputs=0) bool &ret_store(bool temp) {


### PR DESCRIPTION
Swig has changed language specific AppendOutput functions.
The helper macro SWIG_AppendOutput remains unchanged.
Use that instead of SWIG_Python_AppendOutput, which would require an extra parameter since swig 4.3.0.

```
[ 80%] Building CXX object library/forms/swig/CMakeFiles/_cairo.dir/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx.o
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx: In function ‘PyObject* _wrap_cairo_text_extents(PyObject*, PyObject*)’:
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:5421:40: error: too few arguments to function ‘PyObject* SWIG_Python_AppendOutput(PyObject*, PyObject*, int)’
 5421 |     resultobj= SWIG_Python_AppendOutput(resultobj, o); }  { }  return resultobj; fail: { }  return NULL; }
      |                ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:1259:1: note: declared here
 1259 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx: In function ‘PyObject* _wrap_cairo_glyph_extents(PyObject*, PyObject*)’:
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:5436:40: error: too few arguments to function ‘PyObject* SWIG_Python_AppendOutput(PyObject*, PyObject*, int)’
 5436 |     resultobj= SWIG_Python_AppendOutput(resultobj, o); }  return resultobj; fail: return NULL; }
      |                ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:1259:1: note: declared here
 1259 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx: In function ‘PyObject* _wrap_cairo_scaled_font_text_extents(PyObject*, PyObject*)’:
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:5565:40: error: too few arguments to function ‘PyObject* SWIG_Python_AppendOutput(PyObject*, PyObject*, int)’
 5565 |     resultobj= SWIG_Python_AppendOutput(resultobj, o); }  { }  return resultobj; fail: { }  return NULL; }
      |                ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:1259:1: note: declared here
 1259 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx: In function ‘PyObject* _wrap_cairo_scaled_font_glyph_extents(PyObject*, PyObject*)’:
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:5581:40: error: too few arguments to function ‘PyObject* SWIG_Python_AppendOutput(PyObject*, PyObject*, int)’
 5581 |     resultobj= SWIG_Python_AppendOutput(resultobj, o); }  return resultobj; fail: return NULL; }
      |                ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/tmp/sbopkg.4qPKWO/mysql-workbench-community-8.0.40-src/wb-build/library/forms/swig/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx:1259:1: note: declared here
 1259 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [library/forms/swig/CMakeFiles/_cairo.dir/build.make:76: library/forms/swig/CMakeFiles/_cairo.dir/CMakeFiles/_cairo.dir/cairoPYTHON_wrap.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1850: library/forms/swig/CMakeFiles/_cairo.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

ref:
- https://github.com/dgibson/dtc/pull/154
- https://github.com/swig/swig/commit/cd39cf1