### PR TITLE
Reverse SQL history order to show latest queries first

### DIFF
--- a/backend/wbprivate/sqlide/db_sql_editor_history_be.cpp
+++ b/backend/wbprivate/sqlide/db_sql_editor_history_be.cpp
@@ -383,7 +383,14 @@ void DbSqlEditorHistory::DetailsModel::load(const std::string &storage_file_path
         xmlFree(xmlDoc);
       }
 
-      std::reverse(_data.begin(), _data.end());
+      
+      size_t num_entries = _data.size() / 2; // Each entry has now 2 elements (timestamp + SQL)
+      for (size_t i = 0; i < num_entries / 2; ++i) {
+      size_t front = i * 2;
+      size_t back = (num_entries - 1 - i) * 2;
+      std::swap(_data[front], _data[back]);         // Swap timestamp.
+      std::swap(_data[front + 1], _data[back + 1]); // Swap SQL query
+}
 
       _data_frame_end = _row_count;
 
@@ -472,12 +479,12 @@ void DbSqlEditorHistory::DetailsModel::add_entries(const std::list<std::string> 
           if (*rit != _last_timestamp.toString())
             _last_timestamp = *rit;
 
-          _data.insert(_data.begin(), _last_timestamp);
+          _data.push_back(_last_timestamp);
         } else {
           if (*rit != _last_statement.toString())
             _last_statement = *rit;
 
-          _data.insert(_data.begin(), _last_statement);
+          _data.push_back(_last_statement);
         }
         index++;
       }

--- a/backend/wbprivate/sqlide/db_sql_editor_history_be.cpp
+++ b/backend/wbprivate/sqlide/db_sql_editor_history_be.cpp
@@ -384,12 +384,12 @@ void DbSqlEditorHistory::DetailsModel::load(const std::string &storage_file_path
       }
 
       
-      size_t num_entries = _data.size() / 2; // Each entry has now 2 elements (timestamp + SQL)
+      size_t num_entries = _data.size() / 2; 
       for (size_t i = 0; i < num_entries / 2; ++i) {
       size_t front = i * 2;
       size_t back = (num_entries - 1 - i) * 2;
-      std::swap(_data[front], _data[back]);         // Swap timestamp.
-      std::swap(_data[front + 1], _data[back + 1]); // Swap SQL query
+      std::swap(_data[front], _data[back]);        
+      std::swap(_data[front + 1], _data[back + 1]); 
 }
 
       _data_frame_end = _row_count;


### PR DESCRIPTION
## Problem ##
The SQL query history panel displays entries in ascending order (oldest first), which is counterintuitive.

## Solution ##
Reverse the order of entries when loading the history, ensuring the latest queries appear first.