### PR TITLE
remove: gnome-keyring from dependencies in .spec file

### DIFF
--- a/build/mysql-workbench.spec.in
+++ b/build/mysql-workbench.spec.in
@@ -120,7 +120,6 @@ BuildRequires: jasper-devel
 Provides: mysql-workbench = %{version}-%{release}
 Provides: mysql-workbench%{?_isa} = %{version}-%{release}
 Requires: libzip
-Requires: gnome-keyring
 Requires: glib2 >= 2.28
 Requires: gtk3
 Requires: gtkmm30


### PR DESCRIPTION
Currently, `gnome-keyring` is not actually required for mysql-workbench to function, as it has been replaced by `libsecret`.

This PR removes this dependency, which forced mysql-workbench users to install `gnome-keyring` unnecessarily.