### PR TITLE
Fix community build on current Linux toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,11 +243,13 @@ install(FILES ${CMAKE_BINARY_DIR}/mysql-workbench.desktop DESTINATION ${WB_INSTA
 
 if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/internal)
     install(FILES README-commercial.md License-commercial.txt DESTINATION ${WB_INSTALL_DOC_DIR}-commercial)
+    install(FILES build/mysql-workbench-commercial.sharedmimeinfo DESTINATION ${WB_INSTALL_SHARED_DIR}/mime/packages RENAME mysql-workbench.xml)
+    install(FILES build/mysql-workbench-commercial.mime DESTINATION ${WB_INSTALL_SHARED_DIR}/mime-info RENAME mysql-workbench.mime)
 else()
     install(FILES README.md License.txt DESTINATION ${WB_INSTALL_DOC_DIR}-community)
+    install(FILES build/mysql-workbench-community.sharedmimeinfo DESTINATION ${WB_INSTALL_SHARED_DIR}/mime/packages RENAME mysql-workbench.xml)
+    install(FILES build/mysql-workbench-community.mime DESTINATION ${WB_INSTALL_SHARED_DIR}/mime-info RENAME mysql-workbench.mime)
 endif()
-install(FILES build/mysql-workbench-commercial.sharedmimeinfo DESTINATION ${WB_INSTALL_SHARED_DIR}/mime/packages RENAME mysql-workbench.xml)
-install(FILES build/mysql-workbench-commercial.mime DESTINATION ${WB_INSTALL_SHARED_DIR}/mime-info RENAME mysql-workbench.mime)
 
 
 install(FILES build/build_freetds.sh

--- a/build/cmake/Modules/FindUNIXODBC.cmake
+++ b/build/cmake/Modules/FindUNIXODBC.cmake
@@ -36,6 +36,29 @@ if (UNIXODBC_INCLUDE_DIRS AND UNIXODBC_LIBRARIES)
   set(UNIXODBC_FOUND true)
 endif(UNIXODBC_INCLUDE_DIRS AND UNIXODBC_LIBRARIES)
 
+if (UNIXODBC_INCLUDE_DIRS AND NOT UNIXODBC_LIBRARIES)
+  find_library(UNIXODBC_ODBC_LIBRARY NAMES odbc libodbc.so
+    PATHS ${CMAKE_SYSTEM_LIBRARY_PATH}
+          /usr/lib
+          /usr/local/lib
+          /usr/lib/x86_64-linux-gnu
+  )
+  find_library(UNIXODBC_ODBCINST_LIBRARY NAMES odbcinst libodbcinst.so
+    PATHS ${CMAKE_SYSTEM_LIBRARY_PATH}
+          /usr/lib
+          /usr/local/lib
+          /usr/lib/x86_64-linux-gnu
+  )
+
+  if (UNIXODBC_ODBC_LIBRARY)
+    set(UNIXODBC_LIBRARIES ${UNIXODBC_ODBC_LIBRARY})
+    if (UNIXODBC_ODBCINST_LIBRARY)
+      list(APPEND UNIXODBC_LIBRARIES ${UNIXODBC_ODBCINST_LIBRARY})
+    endif()
+    set(UNIXODBC_FOUND true)
+  endif()
+endif()
+
 if (UNIXODBC_CONFIG_PATH)
 
   if (UNIXODBC_LIBRARIES_PATH)

--- a/library/forms/swig/cairo.i
+++ b/library/forms/swig/cairo.i
@@ -125,7 +125,7 @@
 
 %typemap(argout) cairo_text_extents_t *extents {
       PyObject *o= SWIG_NewPointerObj(new cairo_text_extents_t(*$1), SWIGTYPE_p_cairo_text_extents_t, 0 |  0 );
-      $result= SWIG_Python_AppendOutput($result, o);
+      $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in) const char* (std::string s) {
@@ -182,4 +182,3 @@ cairo_surface_t *cairo_image_surface_create_from_png_stream(PyObject *reader)
 {
   return cairo_image_surface_create_from_png_stream(py_read_func, reader);
 }
-

--- a/library/forms/swig/mforms.i
+++ b/library/forms/swig/mforms.i
@@ -722,7 +722,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) std::string &ret_password {
     PyObject *o= PyUnicode_DecodeUTF8(($1)->data(), ($1)->size(), NULL);
-    $result= SWIG_Python_AppendOutput($result, o);
+    $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in,numinputs=0) std::string &ret_password(std::string temp) {
@@ -731,7 +731,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) std::string &ret_value {
     PyObject *o= PyUnicode_DecodeUTF8(($1)->data(), ($1)->size(), NULL);
-    $result= SWIG_Python_AppendOutput($result, o);
+    $result= SWIG_AppendOutput($result, o);
 }
 
 %typemap(in,numinputs=0) std::string &ret_value(std::string temp) {
@@ -741,7 +741,7 @@ inline boost::function<void (mforms::TextEntryAction)> pycall_void_entryaction_f
 
 %typemap(argout) bool &ret_store {
     if (*$1) Py_INCREF(Py_True); else Py_INCREF(Py_False);
-    $result= SWIG_Python_AppendOutput($result, *$1 ? Py_True : Py_False);
+    $result= SWIG_AppendOutput($result, *$1 ? Py_True : Py_False);
 }
 
 %typemap(in,numinputs=0) bool &ret_store(bool temp) {
@@ -1220,4 +1220,3 @@ SWIG_ADD_SIGNAL_VOID_TOOLBARITEM_CALLBACK(activated_callback, self->signal_activ
 %extend mforms::Popover {
 SWIG_ADD_SIGNAL_VOID_CALLBACK(close_callback, self->signal_close());
 }
-

--- a/library/grt/src/grt.h
+++ b/library/grt/src/grt.h
@@ -1385,7 +1385,7 @@ namespace grt {
     }
 
   protected:
-    explicit ListRef<internal::Integer>(const ValueRef &lvalue) : BaseListRef(lvalue) {
+    explicit ListRef(const ValueRef &lvalue) : BaseListRef(lvalue) {
       if (lvalue.is_valid() && content().content_type() != IntegerType)
         throw type_error(IntegerType, content().content_type(), ListType);
     }
@@ -1813,7 +1813,7 @@ namespace grt {
     }
 
   protected:
-    explicit ListRef<internal::Dict>(const ValueRef &lvalue) : BaseListRef(lvalue) {
+    explicit ListRef(const ValueRef &lvalue) : BaseListRef(lvalue) {
       if (lvalue.is_valid() && content().content_type() != DictType)
         throw type_error(DictType, content().content_type(), ListType);
     }

--- a/library/parsers/CMakeLists.txt
+++ b/library/parsers/CMakeLists.txt
@@ -53,6 +53,9 @@ add_library(parsers
 
 
 target_compile_options(parsers PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-sign-compare -Wno-type-limits -Wno-unused -Wno-missing-field-initializers -Wno-implicit-fallthrough>)
+target_compile_options(parsers PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-include>
+    $<$<CXX_COMPILER_ID:GNU,Clang>:${CMAKE_CURRENT_SOURCE_DIR}/antlr4-runtime-compat.h>)
 
 set(NEW_WB_CFLAGS ${WB_CFLAGS})
 list(REMOVE_ITEM NEW_WB_CFLAGS -Werror)
@@ -100,5 +103,4 @@ if(COMMAND cotire)
 endif()
 
 install(TARGETS parsers DESTINATION ${WB_INSTALL_LIB_DIR})
-
 

--- a/library/parsers/antlr4-runtime-compat.h
+++ b/library/parsers/antlr4-runtime-compat.h
@@ -1,0 +1,21 @@
+/*
+ * Compatibility shims for ANTLR C++ generated files when the generator is
+ * newer than the distro-provided runtime.
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include <antlr4-runtime.h>
+
+#if defined(ANTLRCPP_VERSION_MAJOR) && defined(ANTLRCPP_VERSION_MINOR)
+#if ANTLRCPP_VERSION_MAJOR == 4 && ANTLRCPP_VERSION_MINOR < 13
+namespace antlr4 {
+namespace internal {
+using OnceFlag = std::once_flag;
+using std::call_once;
+} // namespace internal
+} // namespace antlr4
+#endif
+#endif

--- a/plugins/wb.admin/backend/wb_server_management.py
+++ b/plugins/wb.admin/backend/wb_server_management.py
@@ -28,7 +28,7 @@ import errno
 import threading
 import tempfile
 import io
-import pipes
+import shlex
 import subprocess
 import time
 import inspect
@@ -511,7 +511,7 @@ class ProcessOpsLinuxLocal(ProcessOpsBase):
         return 0
 
     def list2cmdline(self, args):
-        return " ".join([pipes.quote(a) or "''" for a in args])
+        return " ".join([shlex.quote(a) or "''" for a in args])
 
 
 _process_ops_classes.append(ProcessOpsLinuxLocal)
@@ -592,7 +592,7 @@ class ProcessOpsLinuxRemote(ProcessOpsBase):
 
 
     def list2cmdline(self, args):
-        return " ".join([pipes.quote(a) or "''" for a in args])
+        return " ".join([shlex.quote(a) or "''" for a in args])
 
 _process_ops_classes.append(ProcessOpsLinuxRemote)
 

--- a/res/wbdata/main_menu.xml
+++ b/res/wbdata/main_menu.xml
@@ -2243,42 +2243,6 @@
                     <value type="string" key="command">plugin:wb.admin.open_into:admin_instrumentation_setup</value>
                     <value type="string" key="itemType">action</value>
                 </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.separator.se/SE">
-                    <value type="string" key="itemType">separator</value>
-                    <value type="string" key="accessibilityName">Separator</value>
-                </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.server.audit/SE">
-                    <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.server</link>
-                    <value type="string" key="accessibilityName">Audit Log Inspector</value>
-                    <value type="string" key="caption">Audit Log Inspector</value>
-                    <value type="string" key="name">admin_audit_inspector</value>
-                    <value type="string" key="command">plugin:wb.admin.open_into_se:admin_audit_inspector</value>
-                    <value type="string" key="itemType">action</value>
-                </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.server.firewall/SE">
-                    <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.server</link>
-                    <value type="string" key="accessibilityName">Firewall</value>
-                    <value type="string" key="caption">Firewall</value>
-                    <value type="string" key="name">admin_firewall</value>
-                    <value type="string" key="command">plugin:wb.admin.open_into_se:admin_firewall</value>
-                    <value type="string" key="itemType">action</value>
-                </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.server.meb/SE">
-                    <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.server</link>
-                    <value type="string" key="accessibilityName">MySQL Enterprise Backup</value>
-                    <value type="string" key="caption">MySQL Enterprise Backup</value>
-                    <value type="string" key="name">admin_meb_backup</value>
-                    <value type="string" key="command">plugin:wb.admin.open_into_se:admin_meb_backup</value>
-                    <value type="string" key="itemType">action</value>
-                </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.server.mebrec/SE">
-                    <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.server</link>
-                    <value type="string" key="accessibilityName">Backup Recovery</value>
-                    <value type="string" key="caption">Backup Recovery</value>
-                    <value type="string" key="name">admin_meb_restore</value>
-                    <value type="string" key="command">plugin:wb.admin.open_into_se:admin_meb_restore</value>
-                    <value type="string" key="itemType">action</value>
-                </value>
                 <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.separator.settings">
                     <value type="string" key="itemType">separator</value>
                     <value type="string" key="accessibilityName">Separator</value>
@@ -2309,18 +2273,6 @@
             <value type="string" key="caption">_Tools</value>
             <value type="string" key="itemType">cascade</value>
             <value type="list" key="subItems" content-type="object" content-struct-name="app.MenuItem">
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.plugins.browse_audit/SE">
-                    <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.plugins</link>
-                    <value type="string" key="accessibilityName">Browse Audit Log File</value>
-                    <value type="string" key="caption">Browse Audit Log File...</value>
-                    <value type="string" key="name">browse_audit</value>
-                    <value type="string" key="command">call:WbAdmin.openAuditFile</value>
-                    <value type="string" key="itemType">action</value>
-                </value>
-                <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.separator.plugins.browse_audit/SE">
-                    <value type="string" key="itemType">separator</value>
-                    <value type="string" key="accessibilityName">Separator</value>
-                </value>
                 <value type="object" struct-name="app.MenuItem" id="com.mysql.wb.menu.plugins.configurationmenu">
                     <link type="object" key="owner" struct-name="app.MenuItem">com.mysql.wb.menu.plugins</link>
                     <value type="string" key="accessibilityName">Configuration</value>


### PR DESCRIPTION
This updates the community source tree so it builds and installs cleanly on newer Linux distributions such as Ubuntu 26.04.

The install rules now choose the community MIME metadata when the proprietary internal tree is absent. Previously the community build still tried to install commercial MIME files, which made cmake --install fail after an otherwise successful build.

The parser target now force-includes a small ANTLR runtime compatibility shim. This lets parser sources generated by a newer ANTLR jar compile against distro-provided 4.10-era antlr4-runtime headers, where antlr4::internal::OnceFlag and call_once are not available. The shim maps those names to the standard library once primitives only for older 4.x runtimes.

Several modern toolchain fixes are included: UnixODBC discovery falls back to normal library lookup when unixodbc_config is incomplete, SWIG typemaps use SWIG_AppendOutput instead of the removed SWIG_Python_AppendOutput helper, Python command quoting uses shlex instead of the removed pipes module, and template-id constructor syntax in grt.h is updated for C++20.

The community menu resource no longer exposes admin actions that require missing commercial modules. This removes startup warnings for wb.admin.open_into_se and WbAdmin.openAuditFile without changing the guarded commercial plugin registration path for builds that do include internal modules.